### PR TITLE
More flexible rewriter inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
 [[package]]
 name = "http-handler"
 version = "1.0.0"
+source = "git+ssh://git@github.com/platformatic/http-handler#feb3f00b1f548c581608974ae228dac8c7125f94"
 dependencies = [
  "async-trait",
  "bytes",
@@ -146,9 +147,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "napi"
-version = "3.0.0-beta.10"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a8bf588b2ea96bdf618cac8a81b2b6cb5e0f0f86a1ac4ac62859ab78fd79a8"
+checksum = "afaf586c21f260e9dc327ae3585fc6efcbb24a416d5151da38bbd35a1f2663c8"
 dependencies = [
  "bitflags",
  "ctor",
@@ -160,15 +161,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e0e3177307063d3e7e55b7dd7b648cca9d7f46daa35422c0d98cc2bf48c2c1"
+checksum = "dcae8ad5609d14afb3a3b91dee88c757016261b151e9dcecabf1b2a31a6cab14"
 
 [[package]]
 name = "napi-derive"
-version = "3.0.0-beta.10"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf56acb0b78c92cba806a559cfe62513f53cc4a7947807e2ff3c4ef865e9b3a"
+checksum = "43e61844e0c0bb81e711f2084abe7cff187b03ca21ff8b000cb59bbda61e15a9"
 dependencies = [
  "convert_case",
  "ctor",
@@ -180,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "2.0.0-beta.10"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6862700f1bdfe43767dc2fd3577306cf6342431f078b765c8336454dda382f1d"
+checksum = "b7ab19e9b98efb13895f492a2e367ca50c955ac3c4723613af73fdda4011afcc"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -193,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.0.0-alpha.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4401c63f866b42d673a8b213d5662c84a0701b0f6c3acff7e2b9fc439f1675d"
+checksum = "3e4e7135a8f97aa0f1509cce21a8a1f9dcec1b50d8dee006b48a5adb69a9d64d"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ napi-build = { version = "2.2.1", optional = true }
 bytes = "1.10.1"
 http = "1.0"
 regex = "1.11.1"
-# http-handler = { git = "ssh://git@github.com/platformatic/http-handler" }
-http-handler = { path = "../http-handler" }
+http-handler = { git = "ssh://git@github.com/platformatic/http-handler" }
+# http-handler = { path = "../http-handler" }
 napi = { version = "3.0.0-beta.8", features = ["napi4"], optional = true }
 napi-derive = { version = "3.0.0-beta.8", optional = true }


### PR DESCRIPTION
This makes the `args` field optional on both conditions and rewriter configs, so if they have no arguments you can omit the list entirely rather than needing to provide the field with an empty array.

It also exposed the `HrefWriter` to complete compatibility with the original lang_handler implementation. This now covers the complete feature set of `lang_handler` _plus_ it exposes _every condition and rewriter type_ as separate constructors which may be used in-place of the json config form, using a similar fluent API to the Rust versions.